### PR TITLE
[Bugfix] Multiple notebooks plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 _All notable changes to the codebase are documented in this file._
 
+## [0.6.1] - 25.03.2023
+- Fixed bug with multiple NotebookPlugins installed.
+
 ## [0.6.0] - 12.03.2023
 - Added `dtflw.storage.DbfsStorage`.
 - Added a demo project. See `demos/dtflw_intro`.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dtflw",
-    version="0.6.0",
+    version="0.6.1",
 
     description="dtflw is a Python framework for building modular data pipelines based on Databricks dbutils.notebook API.",
     long_description="See [the home page](https://github.com/SoleyIo/dtflw/blob/main/README.md) of the project for details.",

--- a/src/dtflw/flow.py
+++ b/src/dtflw/flow.py
@@ -3,7 +3,7 @@ from typing import Union
 from dtflw.flow_context import FlowContext
 from dtflw.lazy_notebook import LazyNotebook
 from dtflw.plugin import FlowPluginBase, NotebookPluginBase
-
+from functools import partial
 
 class Flow:
     """
@@ -56,8 +56,7 @@ class Flow:
                 new_nb,
                 plugin.action_name,
                 types.MethodType(
-                    lambda notebook, *args, **kwargs:
-                        plugin.act(notebook, self, *args, **kwargs),
+                    partial(plugin.act, new_nb, self),
                     new_nb
                 ))
 

--- a/src/dtflw/flow.py
+++ b/src/dtflw/flow.py
@@ -52,11 +52,13 @@ class Flow:
 
         # Attach plugin actions to a notebook.
         for plugin in self.__nb_plugins.values():
+            
+            p = partial(plugin.act, new_nb, self)
             setattr(
                 new_nb,
                 plugin.action_name,
                 types.MethodType(
-                    partial(plugin.act, new_nb, self),
+                    partial(plugin.act, new_nb),
                     new_nb
                 ))
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -32,6 +32,18 @@ class TestNotebookPlugin(NotebookPluginBase):
         """
         return notebook.get_args()[arg_name]
 
+class TestNotebookPlugin2(NotebookPluginBase):
+
+    @property
+    def action_name(self):
+        return "get_args_count"
+
+    def act(self, notebook: LazyNotebook, flow: Flow, arg_name: str):
+        """
+        Returns arg name.
+        """
+        return len(notebook.get_args())
+
 
 class FlowTestCase(unittest.TestCase):
 
@@ -108,3 +120,33 @@ class FlowTestCase(unittest.TestCase):
         # Assert
         self.assertEqual(nb.rel_path, "project/nb")
         self.assertTrue(hasattr(nb, nb_plg.action_name))
+
+    def test_insall_two_notebook_plugins(self):
+        # Arrange
+        nb_plg1 = TestNotebookPlugin()
+        nb_plg2 = TestNotebookPlugin2()
+        ctx = FlowContext(None, None, None, DefaultLogger())
+        flow = Flow(ctx)
+
+        flow.install(nb_plg1)
+        flow.install(nb_plg2)
+
+        # Act
+        expected1 = "foo"
+        expected2 = 1
+
+        actual1 = (
+            flow.notebook("import_data")
+                .args({"a": expected1})
+                .get_arg_value("a")
+        )
+
+        actual2 = (
+            flow.notebook("import_data")
+                .args({"a": expected2})
+                .get_args_count("a")
+        )
+
+        # Assert
+        self.assertEqual(expected1, actual1)
+        self.assertEqual(expected2, actual2)


### PR DESCRIPTION
This PR fixes issue when several Notebook plugins are installed. 
Now, the call of any new method added by the registered plugins returns the result of the last registered plugin.