### PR TITLE
Improve outputs validation performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 _All notable changes to the codebase are documented in this file._
 
+## [0.6.4] - 09.04.2023
+- Improve validation, skip reading output table if table expected_columns are not set.
+
 ## [0.6.3] - 09.04.2023
 - Fixed bug with defining params for the act method of the notebook plugin.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dtflw",
-    version="0.6.3",
+    version="0.6.4",
 
     description="dtflw is a Python framework for building modular data pipelines based on Databricks dbutils.notebook API.",
     long_description="See [the home page](https://github.com/SoleyIo/dtflw/blob/main/README.md) of the project for details.",

--- a/src/dtflw/output_table.py
+++ b/src/dtflw/output_table.py
@@ -41,10 +41,11 @@ class OutputTable():
         if self.needs_eval():
             raise Exception("Expected output not found.")
 
-        df = self.__ctx.storage.read_table(self.abs_file_path)
+        if self.__expected_columns:
+            df = self.__ctx.storage.read_table(self.abs_file_path)
 
-        A.assert_schema_compatible(
-            df.dtypes,
-            self.__expected_columns or [],
-            strict
-        )
+            A.assert_schema_compatible(
+                df.dtypes,
+                self.__expected_columns,
+                strict
+            )


### PR DESCRIPTION
Skip reading output table if expected columns are not set