### PR TITLE
Fixed some functions of dtflw.databricks module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 _All notable changes to the codebase are documented in this file._
 
 ## [0.6.5] - 08.10.2023
-- Fixed: `NoSuchElementException` java exception may belong not only to `java.util` namespace.
+- Fixed: some functions of `dtflw.databricks` used to catch and filter for `java.util.NoSuchElementException`.
+Filtering has been removed since it may be a different exception class.
 
 ## [0.6.4] - 09.04.2023
 - Improve validation, skip reading output table if table expected_columns are not set.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changes
 _All notable changes to the codebase are documented in this file._
 
+## [0.6.5] - 08.10.2023
+- Fixed: `NoSuchElementException` java exception may belong not only to `java.util` namespace.
+
 ## [0.6.4] - 09.04.2023
 - Improve validation, skip reading output table if table expected_columns are not set.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="dtflw",
-    version="0.6.4",
+    version="0.6.5",
 
     description="dtflw is a Python framework for building modular data pipelines based on Databricks dbutils.notebook API.",
     long_description="See [the home page](https://github.com/SoleyIo/dtflw/blob/main/README.md) of the project for details.",

--- a/src/dtflw/databricks.py
+++ b/src/dtflw/databricks.py
@@ -79,7 +79,7 @@ def try_get_context_tag(key, defaut=None):
         dbutils = get_dbutils()
         return dbutils.notebook.entry_point.getDbutils().notebook().getContext().tags().apply(key)
     except Exception as e:
-        if "java.util.NoSuchElementException: key not found" in str(e):
+        if "NoSuchElementException" in str(e):
             return defaut
         else:
             raise
@@ -114,6 +114,6 @@ def runtime_config_has(key: str):
     try:
         get_runtime_config_property(key)
     except Exception as e:
-        if "java.util.NoSuchElementException" in str(e):
+        if "NoSuchElementException" in str(e):
             return False
     return True

--- a/src/dtflw/databricks.py
+++ b/src/dtflw/databricks.py
@@ -78,11 +78,8 @@ def try_get_context_tag(key, defaut=None):
     try:
         dbutils = get_dbutils()
         return dbutils.notebook.entry_point.getDbutils().notebook().getContext().tags().apply(key)
-    except Exception as e:
-        if "NoSuchElementException" in str(e):
-            return defaut
-        else:
-            raise
+    except:
+        return defaut
 
 
 def is_job_interactive() -> bool:
@@ -113,7 +110,7 @@ def runtime_config_has(key: str):
     """
     try:
         get_runtime_config_property(key)
-    except Exception as e:
-        if "NoSuchElementException" in str(e):
-            return False
+    except:
+        return False
+
     return True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,7 +97,7 @@ class SparkSessionMock:
 
         def get(self, key):
             if key not in self._conf:
-                raise Exception("NoSuchElementException")
+                raise NameError(key)
             return self._conf[key]
 
         def set(self, key, value):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,7 +97,7 @@ class SparkSessionMock:
 
         def get(self, key):
             if key not in self._conf:
-                raise Exception("java.util.NoSuchElementException")
+                raise Exception("NoSuchElementException")
             return self._conf[key]
 
         def set(self, key, value):


### PR DESCRIPTION
Some functions used to catch and filter specifically for `java.util.NoSuchElementException` exception. 
As learned, it could be a different class, e.g. `org.apache.spark.SparkNoSuchElementException`.

Fix: removed filtering.